### PR TITLE
#3 Subscribe button w/Klaviyo integration

### DIFF
--- a/assets/css/subscribe.css
+++ b/assets/css/subscribe.css
@@ -45,12 +45,12 @@
 
 .subscribe-button:hover {background-color: #1ddba5;border-color: transparent;color: white;}
 .subscribe-notify {
-    display: block;
-    position: relative;
+    position: absolute;
+    top: 75px;
     font-size: .9rem;
     color: #ffafaf;
+    max-width: 300px;
     margin-left: 20px;
-    padding-bottom: 50px;
 }
 .subscribe-notify-success {
     color: #00edb1;

--- a/index.html
+++ b/index.html
@@ -151,19 +151,32 @@
                                             <div class="column is-5 is-offset-1 subscribe-column">
                         <div class="minimal-feature">
                             <h2 class="title minimal-title bold-text light-text no-margin subscribe-title">Stay Tuned!</h2>
-
-                            <div class="control subscribe-form">
-                            <input type="text" class="subscribe-input" placeholder="Enter your email">
-                            <button type="button" class="button input-button subscribe-button">OK</button>
                            
+                            <form id="email_signup" class="control subscribe-form" action="https://manage.kmail-lists.com/subscriptions/subscribe?g=NMPKcu" data-ajax-submit="https://manage.kmail-lists.com/ajax/subscriptions/subscribe?g=NMPKcu" method="GET" target="_blank" novalidate="novalidate">
+                                <input type="hidden" name="g" value="NMPKcu">
+                                <input type="text" name="email" id="k_id_email" class="subscribe-input" placeholder="Enter your email">
+                                <div class="klaviyo_form_actions">
+                                    <button type="submit" class="button input-button subscribe-button">OK</button>
+                                </div>
+                                <div class="success_message subscribe-notify subscribe-notify-success" style="display: none;">
+                                    Thank you! Keep an eye out for updates!
+                                </div>
+                                <div class="error_message subscribe-notify subscribe-notify-failure" style="display: none;">
+                                    Not a valid email. Try again.
+                                </div>
+                            </form>
+                            <script type="text/javascript" src="https://www.klaviyo.com/media/js/public/klaviyo_subscribe.js"></script>
+                            <script type="text/javascript">
+                                KlaviyoSubscribe.attachToForms('#email_signup', {
+                                    custom_error_message: true,
+                                    custom_success_message: true,
+                                    extra_properties: {
+                                        $source: 'CubedSubscribe',
+                                        Brand: 'Cubed',
+                                    }
+                                });
+                            </script> 
 
-
-                        </div>
-                         
-                            <div class="subscribe-notify">
-                            <p class="subscribe-notify-success">Thank you! Keep an eye out for updates!</a></p>
-                            <p class="subscribe-notify-failure">Not a valid email. Try again.</a></p>
-                            </div>
                         </div>
                     </div>
                     <!-- /CTA content -->


### PR DESCRIPTION
### Changes
Resolves #3 

- Adds Klaviyo support to the `Subscribe` form
- Updated notification text styles

NOTES:
- Klaviyo uses dynamic protocol links in their scripts (i think to avoid mixed content delivery errors), so these changes can't be tested by simply opening the HTML file in a browser (that would result in their urls all starting with `file://`) ... in order to test this properly, follow these simple steps:
  - run `npm i -g http-server`
  - from the root directory, run `http-server`
  - use one of the links generated to access `index.html`
- You should be able to verify everything is working by receiving a confirmation email in your inbox from Multichain Ventures after subscribing

### Checklist
- [ ] UAT